### PR TITLE
Removed 'maximum-scale=1' from viewport meta tag - we want tablet users to be able to zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<link rel="Shortcut Icon" href="/favicon.ico" type="image/x-icon" />
 	<meta http-equiv="pragma" content="no-cache" />
 	<meta name="robots" content="all" />
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<!--[if lt IE 9]>
 	<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->	


### PR DESCRIPTION
Example from 8/19 git talk!

:fire: 

:shipit: 
